### PR TITLE
Rapidez v1 proper support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "illuminate/database": "^9.0|^10.0",
         "illuminate/support": "^9.0|^10.0",
         "illuminate/view": "^9.0|^10.0",
-        "rapidez/core": "^1.0"
+        "rapidez/core": "~0.77|^1.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "illuminate/database": "^9.0|^10.0",
         "illuminate/support": "^9.0|^10.0",
         "illuminate/view": "^9.0|^10.0",
-        "rapidez/core": "~0.77|^1.0"
+        "rapidez/core": "^1.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Models/AmastyAmshopbyOptionSetting.php
+++ b/src/Models/AmastyAmshopbyOptionSetting.php
@@ -52,7 +52,7 @@ class AmastyAmshopbyOptionSetting extends Model
     public function optionValue()
     {
         return $this->hasOne(
-            config('rapidez.models.option_value'),
+            config('rapidez.models.optionvalue', config('rapidez.models.option_value')),
             'option_id',
             'value',
         )

--- a/src/Models/AmastyAmshopbyOptionSetting.php
+++ b/src/Models/AmastyAmshopbyOptionSetting.php
@@ -52,7 +52,7 @@ class AmastyAmshopbyOptionSetting extends Model
     public function optionValue()
     {
         return $this->hasOne(
-            config('rapidez.models.optionvalue'),
+            config('rapidez.models.option_value'),
             'option_id',
             'value',
         )


### PR DESCRIPTION
Because this config name changed, we can't easily support rapidez v0.x with this update. Could add in a fallback, but that seems excessive.