### PR TITLE
Listen to Show in Brand List Widget option

### DIFF
--- a/src/Widgets/BrandList.php
+++ b/src/Widgets/BrandList.php
@@ -22,6 +22,7 @@ class BrandList
                 ->join('eav_attribute_option_value', 'amasty_amshopby_option_setting.value', '=', 'eav_attribute_option_value.option_id')
                 ->join('catalog_product_flat_'.config('rapidez.store'), 'amasty_amshopby_option_setting.value', '=', 'catalog_product_flat_'.config('rapidez.store').'.'.$attribute)
                 ->where('eav_attribute_option_value.store_id', 0)
+                ->where('amasty_amshopby_option_setting.is_show_in_widget', 1)
                 ->groupBy('amasty_amshopby_option_setting.value')
                 ->get(),
         ])->render();


### PR DESCRIPTION
This causes the Brand List widget to display only the brands where the **Show in Brand List Widget** option is active.

![image](https://github.com/rapidez/amasty-shop-by-brand/assets/54107647/a4f781ae-7d63-4e33-bb56-fbce7ac242f8)
